### PR TITLE
fix: use platform-safe TCP_NODELAY constant for FreeBSD support

### DIFF
--- a/src/Client.zig
+++ b/src/Client.zig
@@ -48,6 +48,15 @@ pub const HeaderMap = protocol.HeaderMap;
 const nkey_auth = @import("auth.zig");
 const creds_auth = nkey_auth.creds;
 
+// TCP_NODELAY socket option value.
+// std.posix.TCP is void on some platforms (e.g. FreeBSD) where Zig's
+// stdlib does not yet define TCP socket options. TCP_NODELAY is
+// universally 1 on all POSIX platforms (Linux, macOS, *BSD, etc.).
+const TCP_NODELAY: u32 = if (std.posix.TCP != void)
+    std.posix.TCP.NODELAY
+else
+    1;
+
 const Client = @This();
 
 /// Type-erased message handler for callback subscriptions.
@@ -947,7 +956,7 @@ pub fn connect(
     std.posix.setsockopt(
         client.stream.socket.handle,
         std.posix.IPPROTO.TCP,
-        std.posix.TCP.NODELAY,
+        TCP_NODELAY,
         std.mem.asBytes(&enable),
     ) catch {
         client.tcp_nodelay_set = false;
@@ -4085,7 +4094,7 @@ pub fn tryConnect(
     std.posix.setsockopt(
         self.stream.socket.handle,
         std.posix.IPPROTO.TCP,
-        std.posix.TCP.NODELAY,
+        TCP_NODELAY,
         std.mem.asBytes(&enable),
     ) catch {};
 

--- a/src/Client.zig
+++ b/src/Client.zig
@@ -48,15 +48,6 @@ pub const HeaderMap = protocol.HeaderMap;
 const nkey_auth = @import("auth.zig");
 const creds_auth = nkey_auth.creds;
 
-// TCP_NODELAY socket option value.
-// std.posix.TCP is void on some platforms (e.g. FreeBSD) where Zig's
-// stdlib does not yet define TCP socket options. TCP_NODELAY is
-// universally 1 on all POSIX platforms (Linux, macOS, *BSD, etc.).
-const TCP_NODELAY: u32 = if (std.posix.TCP != void)
-    std.posix.TCP.NODELAY
-else
-    1;
-
 const Client = @This();
 
 /// Type-erased message handler for callback subscriptions.
@@ -956,7 +947,7 @@ pub fn connect(
     std.posix.setsockopt(
         client.stream.socket.handle,
         std.posix.IPPROTO.TCP,
-        TCP_NODELAY,
+        defaults.Posix.tcp_nodelay,
         std.mem.asBytes(&enable),
     ) catch {
         client.tcp_nodelay_set = false;
@@ -4094,7 +4085,7 @@ pub fn tryConnect(
     std.posix.setsockopt(
         self.stream.socket.handle,
         std.posix.IPPROTO.TCP,
-        TCP_NODELAY,
+        defaults.Posix.tcp_nodelay,
         std.mem.asBytes(&enable),
     ) catch {};
 

--- a/src/defaults.zig
+++ b/src/defaults.zig
@@ -168,3 +168,19 @@ pub const Tls = struct {
     /// Using 32KB for good performance.
     pub const buffer_size: usize = 32 * 1024;
 };
+
+/// Platform-portability shims for socket and OS-level constants
+/// that Zig's stdlib does not yet expose uniformly across targets.
+pub const Posix = struct {
+    const std = @import("std");
+
+    /// TCP_NODELAY socket option value.
+    /// `std.posix.TCP` is `void` on platforms where Zig's stdlib has
+    /// not yet defined TCP socket options (e.g. FreeBSD). POSIX
+    /// defines TCP_NODELAY = 1 on every platform, so we fall back
+    /// to that literal when the stdlib name is unavailable.
+    pub const tcp_nodelay: u32 = if (std.posix.TCP != void)
+        std.posix.TCP.NODELAY
+    else
+        1;
+};


### PR DESCRIPTION
`std.posix.TCP` is `void` on FreeBSD (and other BSDs) in Zig 0.16 because the stdlib does not yet define TCP socket options for these platforms. This causes a compile error when building nats.zig on FreeBSD:

```
src/Client.zig:950:22: error: type 'void' has no members
        std.posix.TCP.NODELAY,
```

This PR defines a local `TCP_NODELAY` constant that:
- Uses `std.posix.TCP.NODELAY` when available (Linux, macOS, etc.)
- Falls back to `1` — the POSIX-standard value, universal across all platforms

Tested on FreeBSD 15.0 with Zig 0.16.0.