### PR TITLE
Add ADR-47 Request Many (scatter/gather)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,129 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+> The library is pre-1.0. Public API may change between minor
+> versions; any such change is listed under **Changed** with the
+> migration in the entry itself.
+
+## [Unreleased]
+
+### Added
+
+- **Scatter/gather `requestMany` (ADR-47).** New
+  `Client.requestMany(subject, payload, opts)` returns an iterator
+  over multiple replies to a single request, and
+  `Client.requestManyCallback(...)` delivers them through a
+  `MsgHandler` and returns a summary. Stop conditions: total
+  deadline (`max_wait_ms`), inter-reply stall timer (`stall_ms`),
+  delivered count (`max_messages`), and user-supplied `Sentinel`
+  predicate. A server-side 503 ("no responders") is detected and
+  surfaced as `termination = .no_responders`. The implementation
+  uses a dedicated two-token inbox subscription that does not
+  collide with the shared `request()` response multiplexer.
+- **`Sentinel` and `emptyPayloadSentinel()`** are re-exported
+  from the `nats` module. `emptyPayloadSentinel()` provides the
+  ADR-47 standard "empty payload terminates the stream" marker;
+  user code can also build custom predicates over message
+  payload, subject, or headers.
+- **`example-request-many`** demonstrates both the iterator and
+  callback forms against an in-process 3-worker scatter service.
+  Run with `zig build run-request-many`.
+
+### Fixed
+
+- **TLS handshake state machine.** `tls://` URLs now fail closed
+  when TLS cannot be negotiated, and reconnect honors each server
+  URL's scheme rather than only the first URL's scheme.
+- **Header validation.** Structured header publish paths
+  (`publishWithHeaders`, `publishRequestWithHeaders`, the
+  micro `respondError` path) reject CR/LF/control bytes, DEL, and
+  colon in keys, blocking header-injection vectors.
+- **Authenticated connects can no longer hang.** A successful
+  auth-required connection no longer blocks on a non-existent
+  server acknowledgement.
+- **KV slice lifetimes.** `KeyLister.next()` and
+  `KvWatcher.next()` previously returned slices into a
+  deinitialized message. The watcher/lister now duplicates the
+  key onto its own allocator and frees it on the next call /
+  deinit.
+- **`PullSubscription.consume()` lifetime.** The consume context
+  is now heap-owned; the background task no longer dereferences
+  a pointer to a stack-local that disappeared when
+  `consume()` returned.
+- **`AsyncPublisher.publishWithOpts()` leak on failure.** A
+  failed publish no longer leaves pending futures in the map or
+  inflates the in-flight count.
+- **`Service.addService()` cleanup on partial failure.** A
+  failure between subscription creation and the final flush no
+  longer leaves orphaned monitor subscriptions alive.
+- **Runtime validation before fixed-buffer copies.** Stream
+  names, consumer names, KV bucket names, and the JetStream API
+  prefix are validated with runtime errors instead of
+  debug-only assertions, so release builds reject malformed
+  input safely.
+- **KV scan error propagation.** `keys()`, `history()`,
+  `historyWithOpts()`, and `purgeDeletes()` no longer silently
+  return partial results when the pull errors mid-iteration.
+- **Connection edge cases.** `rtt()` no longer misses the PONG
+  it triggered; the muxer's PONG race is fixed; subscription
+  routing is preserved during concurrent unsubscribe; the
+  initial-connect leak on overlong TLS host is closed.
+
+### Changed
+
+- Several JetStream and Micro public setters that previously
+  relied on `std.debug.assert` for input length now return errors
+  at runtime. Callers that fed validated input see no change;
+  callers that relied on the assert in Debug builds will now see
+  the same condition raised as an error in Release builds.
+- The API quick-reference document was removed in favor of the
+  in-code documentation and the JetStream guide.
+
+### Removed
+
+- `doc/api-quick-reference.md` (superseded).
+
+## [0.1.0] - 2026-04-29
+
+Initial public release.
+
+### Highlights
+
+- Core NATS protocol over `std.Io` (Zig 0.16+), no external C
+  dependencies.
+- Pub/sub with three subscription styles: `subscribe()` /
+  `subscribeFn()` (callback) and `subscribeSync()` (manual
+  receive). Queue group variants for each.
+- Request/reply with a shared response multiplexer
+  (`_INBOX.<NUID>.*`) that amortizes inbox SUB/UNSUB across
+  requests, and `msg.respond()` convenience.
+- NATS headers (HPUB/HMSG) with structured publish, parsing,
+  and a `HeaderMap` builder; well-known header constants for
+  JetStream features.
+- Reconnection with backoff, server pool, auto-discovery, and
+  lifecycle events through an `EventHandler` vtable.
+- Authentication: username/password, token, NKey seed (string
+  or file), NKey signing callback for HSM use, and JWT/creds.
+  Programmatic NKey generation and JWT/creds encoding helpers.
+- Server-authenticated TLS via URL scheme or explicit options.
+  mTLS client certificates are reserved but not yet implemented.
+- JetStream: stream and consumer CRUD, publish with ack and
+  deduplication, pull consumers (`fetch`, `fetchNoWait`,
+  `fetchBytes`, `next`, `messages`, `consume`), push consumers
+  with callback delivery, ordered consumers, full ack/nak/term
+  set, JetStream domains, and async publish.
+- Key-Value store: create/update/delete buckets, put/get,
+  create-only and optimistic update by revision, delete and
+  purge, key listing, history, and live watches.
+- Micro services API: discoverable services with `$SRV.PING`,
+  `$SRV.INFO`, `$SRV.STATS`; endpoint groups, queue groups,
+  metadata, stats reset, and drain.
+- Integration test suite covering core, reconnect, JetStream,
+  KV, micro, headers, auth, and TLS scenarios.
+
+[Unreleased]: https://github.com/nats-io/nats.zig/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/nats-io/nats.zig/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Run with `zig build run-<name>` (requires `nats-server` on localhost:4222).
 | events | `run-events` | EventHandler callbacks with external state |
 | callback | `run-callback` | `subscribe()` and `subscribeFn()` callback subscriptions |
 | request_reply_callback | `run-request-reply-callback` | Service responder via callback subscription |
+| request_many | `run-request-many` | Scatter/gather (ADR-47): one request, multiple replies |
 | graceful_shutdown | `run-graceful-shutdown` | `drain()` lifecycle, pre-shutdown health checks |
 | jetstream_publish | `run-jetstream-publish` | Create a stream and publish with ack confirmation |
 | jetstream_consume | `run-jetstream-consume` | Pull consumer fetch and acknowledgement |
@@ -672,6 +673,90 @@ if (reply) |msg| {
     }
 }
 ```
+
+### Scatter/Gather with `requestMany()`
+
+When a single request may have multiple responders -- or when one
+service streams several replies back -- use `requestMany()`. It
+implements [ADR-47 "Request Many"](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-47.md)
+and supports four stop conditions; whichever fires first ends the
+call:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `max_wait_ms` | `u32` (required, > 0) | Overall deadline for the call. |
+| `max_messages` | `u32` (0 disables) | Terminate after N replies. |
+| `stall_ms` | `u32` (0 disables) | Terminate if no reply arrives within this gap. Applies only *after* the first reply. |
+| `sentinel` | `?Sentinel` | Custom predicate that marks end-of-stream. Use `nats.emptyPayloadSentinel()` for the ADR-47 standard empty-payload marker. |
+
+A server 503 ("no responders") is always terminal.
+
+**Iterator form** -- pull replies one at a time, react to each:
+
+```zig
+var iter = try client.requestMany(
+    "rpc.scatter",
+    "ping",
+    .{ .max_wait_ms = 2000, .max_messages = 3 },
+);
+defer iter.deinit();
+
+while (try iter.next()) |msg| {
+    defer msg.deinit();
+    std.debug.print("reply: {s}\n", .{msg.data});
+}
+// iter.termination tells you why the call ended:
+//   .max_messages | .max_wait | .stall | .sentinel | .no_responders | .closed
+```
+
+**Callback form** -- replies dispatched to a `MsgHandler`, freed
+automatically; returns a summary of the run:
+
+```zig
+const Collector = struct {
+    count: u32 = 0,
+    pub fn onMessage(self: *@This(), msg: *const nats.Message) void {
+        self.count += 1;
+    }
+};
+
+var collector = Collector{};
+const result = try client.requestManyCallback(
+    "rpc.scatter",
+    "ping",
+    .{ .max_wait_ms = 2000, .max_messages = 3 },
+    nats.MsgHandler.init(Collector, &collector),
+);
+// result.received, result.termination
+```
+
+**Standard sentinel** -- services that stream replies often publish
+an empty payload to mark end-of-stream:
+
+```zig
+var iter = try client.requestMany(
+    "search.query",
+    "user:42",
+    .{
+        .max_wait_ms = 5000,
+        .sentinel = nats.emptyPayloadSentinel(),
+    },
+);
+defer iter.deinit();
+
+while (try iter.next()) |msg| {
+    defer msg.deinit();
+    // The sentinel message is consumed by the iterator, not yielded.
+}
+```
+
+`requestMany()` uses its own dedicated inbox subscription per call
+(not the shared response multiplexer described below). Each call
+pays one SUB/UNSUB but is fully isolated from concurrent
+single-reply `request()` traffic.
+
+See [`src/examples/request_many.zig`](src/examples/request_many.zig)
+for a runnable demo of both forms.
 
 ### Implementation Note: Response Multiplexer
 
@@ -1770,6 +1855,7 @@ layout, fixtures, and focused test targets.
 | Core Protocol | Supported |
 | Pub/Sub | Supported |
 | Request/Reply | Supported |
+| Scatter/Gather (Request Many, ADR-47) | Supported |
 | Headers | Supported |
 | Reconnection | Supported |
 | Event Callbacks | Supported |

--- a/build.zig
+++ b/build.zig
@@ -337,6 +337,31 @@ pub fn build(b: *std.Build) void {
     run_req_rep_cb.dependOn(&req_rep_cb_cmd.step);
     req_rep_cb_cmd.step.dependOn(b.getInstallStep());
 
+    // 11b. Request Many (scatter/gather, ADR-47) example
+    const request_many_exe = b.addExecutable(.{
+        .name = "example-request-many",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path(
+                "src/examples/request_many.zig",
+            ),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "nats", .module = nats },
+                .{ .name = "io_backend", .module = io_backend_mod },
+            },
+        }),
+    });
+    b.installArtifact(request_many_exe);
+
+    const run_request_many = b.step(
+        "run-request-many",
+        "Run request-many scatter/gather (ADR-47) example",
+    );
+    const request_many_cmd = b.addRunArtifact(request_many_exe);
+    run_request_many.dependOn(&request_many_cmd.step);
+    request_many_cmd.step.dependOn(b.getInstallStep());
+
     // 12. JetStream Publish example
     const js_pub_exe = b.addExecutable(.{
         .name = "example-jetstream-publish",

--- a/src/Client.zig
+++ b/src/Client.zig
@@ -2706,6 +2706,305 @@ pub fn requestMsg(
     return self.requestAwaitResp(&waiter, reply, timeout_ms);
 }
 
+/// Predicate that signals end-of-stream for `requestMany`.
+///
+/// ADR-47 specifies a "standard sentinel" of an empty-payload
+/// reply; `emptyPayloadSentinel()` returns a Sentinel matching
+/// that contract. Custom sentinels can inspect headers, status,
+/// or payload contents to decide termination.
+pub const Sentinel = struct {
+    ptr: *anyopaque,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        isTerminal: *const fn (
+            *anyopaque,
+            *const Message,
+        ) bool,
+    };
+
+    pub fn init(comptime T: type, ptr: *T) Sentinel {
+        const gen = struct {
+            fn isTerminal(
+                p: *anyopaque,
+                msg: *const Message,
+            ) bool {
+                const self: *T = @ptrCast(@alignCast(p));
+                return self.isTerminal(msg);
+            }
+        };
+        return .{
+            .ptr = ptr,
+            .vtable = &.{ .isTerminal = gen.isTerminal },
+        };
+    }
+
+    pub fn check(
+        self: Sentinel,
+        msg: *const Message,
+    ) bool {
+        return self.vtable.isTerminal(self.ptr, msg);
+    }
+};
+
+/// Standard sentinel from ADR-47: terminates on an empty-payload
+/// reply. Common convention for services that explicitly close
+/// a scatter/gather session.
+pub fn emptyPayloadSentinel() Sentinel {
+    const gen = struct {
+        var dummy: u8 = 0;
+        fn isTerminal(
+            _: *anyopaque,
+            msg: *const Message,
+        ) bool {
+            return msg.data.len == 0;
+        }
+    };
+    return .{
+        .ptr = @ptrCast(&gen.dummy),
+        .vtable = &.{ .isTerminal = gen.isTerminal },
+    };
+}
+
+/// Stop conditions for `requestMany` per ADR-47. All conditions
+/// race; whichever fires first terminates the call. `max_wait_ms`
+/// is a hard upper bound and is always honored.
+pub const RequestManyOptions = struct {
+    /// Overall deadline for the call (ms). Must be > 0.
+    max_wait_ms: u32 = 1000,
+
+    /// Stall timer (ms): terminate if no reply arrives within
+    /// this gap from the previous one (or the request itself).
+    /// 0 disables. Effective per-wait deadline is
+    /// `min(stall_ms, remaining of max_wait_ms)`.
+    stall_ms: u32 = 0,
+
+    /// Terminate after delivering this many replies. 0 disables.
+    max_messages: u32 = 0,
+
+    /// Optional predicate; if it returns true for a reply, that
+    /// reply is consumed (not yielded) and the call terminates.
+    /// Use `emptyPayloadSentinel()` for the ADR-47 standard.
+    sentinel: ?Sentinel = null,
+};
+
+/// Why a `requestMany` call terminated.
+pub const RequestManyTermination = enum {
+    /// Overall `max_wait_ms` deadline reached.
+    max_wait,
+    /// `stall_ms` elapsed since the previous reply.
+    stall,
+    /// Delivered `max_messages` replies.
+    max_messages,
+    /// Sentinel predicate matched (sentinel msg was consumed).
+    sentinel,
+    /// Server reported no responders (503).
+    no_responders,
+    /// Subscription closed before the call terminated normally
+    /// (e.g. connection lost).
+    closed,
+};
+
+/// Summary returned by `requestManyCallback`.
+pub const RequestManyResult = struct {
+    received: u32,
+    termination: RequestManyTermination,
+};
+
+/// Iterator yielded by `requestMany`. The caller MUST call
+/// `deinit()` regardless of termination path; it unsubscribes
+/// the dedicated inbox and frees its subject buffer.
+pub const RequestManyIter = struct {
+    client: *Client,
+    sub: *Sub,
+    inbox: []u8,
+    opts: RequestManyOptions,
+    start_ns: u64,
+    received: u32,
+    termination: RequestManyTermination,
+    done: bool,
+
+    /// Returns the next reply or null if a stop condition fired.
+    /// Caller owns the returned message and must call deinit().
+    pub fn next(
+        self: *RequestManyIter,
+    ) !?Message {
+        assert(self.inbox.len > 0);
+        if (self.done) return null;
+        const io = self.client.io;
+
+        const total_ns: u64 = @as(u64, self.opts.max_wait_ms) *
+            std.time.ns_per_ms;
+        assert(total_ns > 0);
+
+        const now = getNowNs(io);
+        const elapsed_ns = now -| self.start_ns;
+        if (elapsed_ns >= total_ns) {
+            self.termination = .max_wait;
+            self.done = true;
+            return null;
+        }
+
+        const remaining_ns = total_ns - elapsed_ns;
+        const remaining_ms_u64 =
+            (remaining_ns + std.time.ns_per_ms - 1) /
+            std.time.ns_per_ms;
+        var wait_ms: u32 = if (remaining_ms_u64 >
+            std.math.maxInt(u32))
+            std.math.maxInt(u32)
+        else
+            @intCast(remaining_ms_u64);
+        if (wait_ms == 0) wait_ms = 1;
+        // ADR-47: stall timer applies only after the first reply.
+        // Before that, the first message gets the full max_wait_ms.
+        const stall_active = self.opts.stall_ms > 0 and
+            self.received > 0;
+        if (stall_active and self.opts.stall_ms < wait_ms) {
+            wait_ms = self.opts.stall_ms;
+        }
+        assert(wait_ms > 0);
+
+        const maybe = self.sub.nextMsgTimeout(wait_ms) catch |err| {
+            self.done = true;
+            if (err == error.Closed) {
+                self.termination = .closed;
+                return null;
+            }
+            return err;
+        };
+        const msg = maybe orelse {
+            self.done = true;
+            const after = getNowNs(io);
+            const elapsed_after = after -| self.start_ns;
+            // Only classify as .stall when the stall timer was the
+            // condition we waited on; otherwise the deadline is the
+            // overall max_wait_ms (including the no-first-reply case).
+            self.termination = if (stall_active and
+                elapsed_after < total_ns)
+                .stall
+            else
+                .max_wait;
+            return null;
+        };
+
+        if (msg.isNoResponders()) {
+            msg.deinit();
+            self.done = true;
+            self.termination = .no_responders;
+            return null;
+        }
+
+        if (self.opts.sentinel) |s| {
+            if (s.check(&msg)) {
+                msg.deinit();
+                self.done = true;
+                self.termination = .sentinel;
+                return null;
+            }
+        }
+
+        self.received += 1;
+        if (self.opts.max_messages > 0 and
+            self.received >= self.opts.max_messages)
+        {
+            self.done = true;
+            self.termination = .max_messages;
+        }
+        return msg;
+    }
+
+    /// Releases the underlying subscription and inbox buffer.
+    /// Safe to call multiple times.
+    pub fn deinit(self: *RequestManyIter) void {
+        if (self.inbox.len == 0) return;
+        self.sub.deinit();
+        self.client.allocator.free(self.inbox);
+        self.inbox = &[_]u8{};
+    }
+};
+
+/// Scatter/gather request: publishes one request to `subject`
+/// and returns an iterator over multiple replies. Stops on the
+/// first matching condition in `opts` (see `RequestManyOptions`).
+///
+/// Implements ADR-47 "Request Many". Equivalent to orbit.go's
+/// `natsext.RequestMany` and orbit.rs's `request_many`.
+///
+/// The iterator owns a dedicated inbox subscription; call
+/// `deinit()` on it regardless of how the loop exits. Each
+/// yielded message is owned by the caller (call `deinit()`).
+///
+/// Lock-free with respect to the shared response multiplexer
+/// used by single-reply `request()` — the dedicated inbox uses
+/// a two-token subject (`<prefix>.<22 random>`) that cannot
+/// match the muxer's three-token wildcard.
+pub fn requestMany(
+    self: *Client,
+    subject: []const u8,
+    payload: []const u8,
+    opts: RequestManyOptions,
+) !RequestManyIter {
+    assert(subject.len > 0);
+    assert(opts.max_wait_ms > 0);
+    if (!State.atomicLoad(&self.state).canSend()) {
+        return error.NotConnected;
+    }
+
+    const inbox = try self.newInbox();
+    errdefer self.allocator.free(inbox);
+
+    const sub = try self.subscribeSync(inbox);
+    errdefer sub.deinit();
+
+    try self.publishRequest(subject, inbox, payload);
+    try self.flushBuffer();
+
+    return .{
+        .client = self,
+        .sub = sub,
+        .inbox = inbox,
+        .opts = opts,
+        .start_ns = getNowNs(self.io),
+        .received = 0,
+        .termination = .max_wait,
+        .done = false,
+    };
+}
+
+/// Callback variant of `requestMany`. Dispatches each reply to
+/// `handler.onMessage` and frees it. Returns the count of
+/// replies delivered and the reason the call ended.
+///
+/// To stop early on a specific reply, use `requestMany` (the
+/// iterator form) or supply a `sentinel` in `opts`.
+pub fn requestManyCallback(
+    self: *Client,
+    subject: []const u8,
+    payload: []const u8,
+    opts: RequestManyOptions,
+    handler: MsgHandler,
+) !RequestManyResult {
+    assert(subject.len > 0);
+    assert(opts.max_wait_ms > 0);
+
+    var iter = try self.requestMany(subject, payload, opts);
+    defer iter.deinit();
+    while (try iter.next()) |msg| {
+        defer msg.deinit();
+        // ADR-47: blocking handler time must not count against
+        // max_wait_ms. Advance start_ns by the dispatch duration so
+        // the next iter.next() sees the same remaining budget.
+        const dispatch_start = getNowNs(self.io);
+        handler.dispatch(&msg);
+        const dispatch_end = getNowNs(self.io);
+        iter.start_ns +|= dispatch_end -| dispatch_start;
+    }
+    return .{
+        .received = iter.received,
+        .termination = iter.termination,
+    };
+}
+
 /// Helper for connection timeout (nanoseconds).
 fn sleepNs(io: Io, timeout_ns: u64) void {
     io.sleep(.fromNanoseconds(timeout_ns), .awake) catch {};

--- a/src/examples/README.md
+++ b/src/examples/README.md
@@ -15,6 +15,7 @@ Run with `zig build run-<name>` (requires `nats-server` on localhost:4222).
 | events | `run-events` | EventHandler callbacks with external state |
 | callback | `run-callback` | `subscribe()` and `subscribeFn()` callback subscriptions |
 | request_reply_callback | `run-request-reply-callback` | Service responder via callback subscription |
+| request_many | `run-request-many` | Scatter/gather (ADR-47): one request, multiple replies, iterator + callback |
 | graceful_shutdown | `run-graceful-shutdown` | `drain()` lifecycle, pre-shutdown health checks |
 | jetstream_publish | `run-jetstream-publish` | Create a stream and publish with ack confirmation |
 | jetstream_consume | `run-jetstream-consume` | Pull consumer fetch and acknowledgement |

--- a/src/examples/request_many.zig
+++ b/src/examples/request_many.zig
@@ -1,0 +1,184 @@
+//! Request Many (Scatter/Gather)
+//!
+//! Implements the ADR-47 "Request Many" pattern: publish one
+//! request and gather multiple replies through a dedicated inbox.
+//! Useful for fan-out RPC, leader-election style probes, and any
+//! workflow where several services answer the same question.
+//!
+//! This example uses a single service connection with three
+//! subscribers on the same subject to act as three "workers".
+//! Each worker replies with its own ID, and the requester
+//! collects all three answers.
+//!
+//! Two forms are demonstrated:
+//!   1. Iterator form  -- pull each reply with `iter.next()`.
+//!   2. Callback form  -- replies dispatched via `MsgHandler`.
+//!
+//! Stop conditions (configured via `RequestManyOptions`):
+//!   - `max_wait_ms`   : total deadline for the call (required)
+//!   - `max_messages`  : terminate after N replies
+//!   - `stall_ms`      : terminate after a gap between replies
+//!   - `sentinel`      : terminate on a predicate match. Use
+//!                       `nats.emptyPayloadSentinel()` for the
+//!                       ADR-47 standard end-of-stream marker.
+//!
+//! Run with: zig build run-request-many
+//!
+//! Prerequisites: nats-server running on localhost:4222
+
+const std = @import("std");
+const nats = @import("nats");
+const io_backend = @import("io_backend");
+
+/// Worker handler: replies with its own ID for each request.
+const Worker = struct {
+    client: *nats.Client,
+    id: u32,
+
+    pub fn onMessage(
+        self: *@This(),
+        msg: *const nats.Message,
+    ) void {
+        var buf: [32]u8 = undefined;
+        const reply = std.fmt.bufPrint(
+            &buf,
+            "worker-{d}",
+            .{self.id},
+        ) catch return;
+        msg.respond(self.client, reply) catch {};
+    }
+};
+
+/// Collector for the callback form: counts and prints each reply.
+const Collector = struct {
+    count: u32 = 0,
+
+    pub fn onMessage(
+        self: *@This(),
+        msg: *const nats.Message,
+    ) void {
+        self.count += 1;
+        std.debug.print(
+            "  reply {d}: {s}\n",
+            .{ self.count, msg.data },
+        );
+    }
+};
+
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+
+    // -------- Service: one connection, three workers --------
+    var svc_backend: io_backend.Backend = undefined;
+    try io_backend.init(&svc_backend, allocator);
+    defer svc_backend.deinit();
+
+    const svc = try nats.Client.connect(
+        allocator,
+        svc_backend.io(),
+        "nats://localhost:4222",
+        .{ .name = "scatter-service" },
+    );
+    defer svc.deinit();
+
+    var w1 = Worker{ .client = svc, .id = 1 };
+    var w2 = Worker{ .client = svc, .id = 2 };
+    var w3 = Worker{ .client = svc, .id = 3 };
+
+    // Three plain (non-queue) subscriptions to the same subject.
+    // The server delivers each request to ALL three -- this is
+    // what makes the pattern "scatter" rather than load-balanced.
+    const sub1 = try svc.subscribe(
+        "rpc.scatter",
+        nats.MsgHandler.init(Worker, &w1),
+    );
+    defer sub1.deinit();
+
+    const sub2 = try svc.subscribe(
+        "rpc.scatter",
+        nats.MsgHandler.init(Worker, &w2),
+    );
+    defer sub2.deinit();
+
+    const sub3 = try svc.subscribe(
+        "rpc.scatter",
+        nats.MsgHandler.init(Worker, &w3),
+    );
+    defer sub3.deinit();
+
+    // Make sure all subscriptions are registered before the
+    // first request lands on the server.
+    try svc.flush(1_000_000_000);
+
+    // -------- Requester: separate connection --------
+    var req_backend: io_backend.Backend = undefined;
+    try io_backend.init(&req_backend, allocator);
+    defer req_backend.deinit();
+
+    const requester = try nats.Client.connect(
+        allocator,
+        req_backend.io(),
+        "nats://localhost:4222",
+        .{ .name = "scatter-requester" },
+    );
+    defer requester.deinit();
+
+    std.debug.print(
+        "Connected. 3 workers listening on 'rpc.scatter'.\n",
+        .{},
+    );
+
+    // -------- Iterator form --------
+    //
+    // Publishes one request, then yields each reply through
+    // `iter.next()`. Caller owns each yielded `Message` and must
+    // call `deinit()`. Caller must also call `iter.deinit()` once
+    // the loop ends, regardless of the termination reason.
+    std.debug.print("\n[iterator]\n", .{});
+    var iter = try requester.requestMany(
+        "rpc.scatter",
+        "ping",
+        .{
+            .max_wait_ms = 2000,
+            .max_messages = 3,
+        },
+    );
+    defer iter.deinit();
+
+    var got: u32 = 0;
+    while (try iter.next()) |msg| {
+        defer msg.deinit();
+        got += 1;
+        std.debug.print(
+            "  reply {d}: {s}\n",
+            .{ got, msg.data },
+        );
+    }
+    std.debug.print(
+        "  ended: received={d} termination={s}\n",
+        .{ got, @tagName(iter.termination) },
+    );
+
+    // -------- Callback form --------
+    //
+    // Same options, but replies are dispatched to a `MsgHandler`
+    // and freed automatically after `onMessage` returns. Returns
+    // a summary with the final count and termination reason.
+    std.debug.print("\n[callback]\n", .{});
+    var collector = Collector{};
+    const result = try requester.requestManyCallback(
+        "rpc.scatter",
+        "ping",
+        .{
+            .max_wait_ms = 2000,
+            .max_messages = 3,
+        },
+        nats.MsgHandler.init(Collector, &collector),
+    );
+    std.debug.print(
+        "  ended: received={d} termination={s}\n",
+        .{ result.received, @tagName(result.termination) },
+    );
+
+    std.debug.print("\nDone!\n", .{});
+}

--- a/src/nats.zig
+++ b/src/nats.zig
@@ -52,6 +52,14 @@ pub const EventHandler = Client.EventHandler;
 // Message callback type (nested in Client)
 pub const MsgHandler = Client.MsgHandler;
 
+// Scatter/gather request (ADR-47, "Request Many")
+pub const RequestManyOptions = Client.RequestManyOptions;
+pub const RequestManyIter = Client.RequestManyIter;
+pub const RequestManyResult = Client.RequestManyResult;
+pub const RequestManyTermination = Client.RequestManyTermination;
+pub const Sentinel = Client.Sentinel;
+pub const emptyPayloadSentinel = Client.emptyPayloadSentinel;
+
 // Events module exports
 const events = @import("events.zig");
 pub const EventError = events.Error;

--- a/src/testing/client/request_reply.zig
+++ b/src/testing/client/request_reply.zig
@@ -789,6 +789,642 @@ pub fn testMuxerTimeoutCleanup(allocator: std.mem.Allocator) void {
     }
 }
 
+const ScatterResponder = struct {
+    fn handle(
+        c: *nats.Client,
+        s: *nats.Subscription,
+        tag: []const u8,
+    ) void {
+        const req = s.nextMsgTimeout(3000) catch return;
+        const m = req orelse return;
+        defer m.deinit();
+        const reply = m.reply_to orelse return;
+        c.publish(reply, tag) catch return;
+    }
+};
+
+pub fn testRequestManyCount(allocator: std.mem.Allocator) void {
+    var url_buf: [64]u8 = undefined;
+    const url = formatUrl(&url_buf, test_port);
+
+    const responder_count: u32 = 3;
+
+    var io_ctxs: [3]*utils.TestIo = undefined;
+    var responders: [3]*nats.Client = undefined;
+    var subs: [3]*nats.Subscription = undefined;
+    var futs: [3]std.Io.Future(void) = undefined;
+
+    var i: usize = 0;
+    while (i < responder_count) : (i += 1) {
+        io_ctxs[i] = utils.newIo(allocator);
+        responders[i] = nats.Client.connect(
+            allocator,
+            io_ctxs[i].io(),
+            url,
+            .{ .reconnect = false },
+        ) catch {
+            reportResult(
+                "request_many_count",
+                false,
+                "responder connect failed",
+            );
+            return;
+        };
+        subs[i] = responders[i].subscribeSync(
+            "rm.count.service",
+        ) catch {
+            reportResult(
+                "request_many_count",
+                false,
+                "responder sub failed",
+            );
+            return;
+        };
+    }
+    defer {
+        var j: usize = responder_count;
+        while (j > 0) : (j -= 1) {
+            _ = futs[j - 1].cancel(io_ctxs[j - 1].io());
+            subs[j - 1].deinit();
+            responders[j - 1].deinit();
+            io_ctxs[j - 1].deinit();
+        }
+    }
+    io_ctxs[0].io().sleep(.fromMilliseconds(50), .awake) catch {};
+
+    i = 0;
+    while (i < responder_count) : (i += 1) {
+        futs[i] = io_ctxs[i].io().async(
+            ScatterResponder.handle,
+            .{ responders[i], subs[i], "ok" },
+        );
+    }
+
+    const io_req = utils.newIo(allocator);
+    defer io_req.deinit();
+    const requester = nats.Client.connect(
+        allocator,
+        io_req.io(),
+        url,
+        .{ .reconnect = false },
+    ) catch {
+        reportResult(
+            "request_many_count",
+            false,
+            "requester connect failed",
+        );
+        return;
+    };
+    defer requester.deinit();
+
+    var iter = requester.requestMany(
+        "rm.count.service",
+        "ping",
+        .{
+            .max_wait_ms = 2000,
+            .max_messages = responder_count,
+        },
+    ) catch {
+        reportResult(
+            "request_many_count",
+            false,
+            "requestMany failed",
+        );
+        return;
+    };
+    defer iter.deinit();
+
+    var got: u32 = 0;
+    while (iter.next() catch null) |msg| {
+        defer msg.deinit();
+        if (std.mem.eql(u8, msg.data, "ok")) got += 1;
+    }
+
+    if (got == responder_count and
+        iter.termination == .max_messages)
+    {
+        reportResult("request_many_count", true, "");
+    } else {
+        var buf: [64]u8 = undefined;
+        const detail = std.fmt.bufPrint(
+            &buf,
+            "got {d}/{d} term={s}",
+            .{ got, responder_count, @tagName(iter.termination) },
+        ) catch "e";
+        reportResult("request_many_count", false, detail);
+    }
+}
+
+pub fn testRequestManySentinel(allocator: std.mem.Allocator) void {
+    var url_buf: [64]u8 = undefined;
+    const url = formatUrl(&url_buf, test_port);
+
+    const io_r = utils.newIo(allocator);
+    defer io_r.deinit();
+    const responder = nats.Client.connect(
+        allocator,
+        io_r.io(),
+        url,
+        .{ .reconnect = false },
+    ) catch {
+        reportResult(
+            "request_many_sentinel",
+            false,
+            "responder connect failed",
+        );
+        return;
+    };
+    defer responder.deinit();
+
+    const sub = responder.subscribeSync(
+        "rm.sentinel.service",
+    ) catch {
+        reportResult(
+            "request_many_sentinel",
+            false,
+            "responder sub failed",
+        );
+        return;
+    };
+    defer sub.deinit();
+    io_r.io().sleep(.fromMilliseconds(50), .awake) catch {};
+
+    const Handler = struct {
+        fn run(c: *nats.Client, s: *nats.Subscription) void {
+            const req = s.nextMsgTimeout(3000) catch return;
+            const m = req orelse return;
+            defer m.deinit();
+            const reply = m.reply_to orelse return;
+            c.publish(reply, "part-1") catch return;
+            c.publish(reply, "part-2") catch return;
+            c.publish(reply, "") catch return;
+        }
+    };
+
+    var fut = io_r.io().async(Handler.run, .{ responder, sub });
+    defer _ = fut.cancel(io_r.io());
+
+    const io_req = utils.newIo(allocator);
+    defer io_req.deinit();
+    const requester = nats.Client.connect(
+        allocator,
+        io_req.io(),
+        url,
+        .{ .reconnect = false },
+    ) catch {
+        reportResult(
+            "request_many_sentinel",
+            false,
+            "requester connect failed",
+        );
+        return;
+    };
+    defer requester.deinit();
+
+    var iter = requester.requestMany(
+        "rm.sentinel.service",
+        "ping",
+        .{
+            .max_wait_ms = 2000,
+            .sentinel = nats.emptyPayloadSentinel(),
+        },
+    ) catch {
+        reportResult(
+            "request_many_sentinel",
+            false,
+            "requestMany failed",
+        );
+        return;
+    };
+    defer iter.deinit();
+
+    var got: u32 = 0;
+    while (iter.next() catch null) |msg| {
+        defer msg.deinit();
+        if (msg.data.len > 0) got += 1;
+    }
+
+    if (got == 2 and iter.termination == .sentinel) {
+        reportResult("request_many_sentinel", true, "");
+    } else {
+        var buf: [64]u8 = undefined;
+        const detail = std.fmt.bufPrint(
+            &buf,
+            "got {d} term={s}",
+            .{ got, @tagName(iter.termination) },
+        ) catch "e";
+        reportResult("request_many_sentinel", false, detail);
+    }
+}
+
+pub fn testRequestManyMaxWait(allocator: std.mem.Allocator) void {
+    var url_buf: [64]u8 = undefined;
+    const url = formatUrl(&url_buf, test_port);
+
+    const io = utils.newIo(allocator);
+    defer io.deinit();
+    const client = nats.Client.connect(
+        allocator,
+        io.io(),
+        url,
+        .{ .reconnect = false, .no_responders = false },
+    ) catch {
+        reportResult(
+            "request_many_max_wait",
+            false,
+            "connect failed",
+        );
+        return;
+    };
+    defer client.deinit();
+
+    const start = std.Io.Timestamp.now(io.io(), .awake);
+
+    var iter = client.requestMany(
+        "rm.absent.subject",
+        "ping",
+        .{ .max_wait_ms = 80 },
+    ) catch {
+        reportResult(
+            "request_many_max_wait",
+            false,
+            "requestMany failed",
+        );
+        return;
+    };
+    defer iter.deinit();
+
+    var got: u32 = 0;
+    while (iter.next() catch null) |msg| {
+        defer msg.deinit();
+        got += 1;
+    }
+
+    const end = std.Io.Timestamp.now(io.io(), .awake);
+    const elapsed_ns: i96 = end.nanoseconds - start.nanoseconds;
+    const elapsed_ms: i64 = @intCast(
+        @divFloor(elapsed_ns, std.time.ns_per_ms),
+    );
+
+    const ok = got == 0 and
+        iter.termination == .max_wait and
+        elapsed_ms >= 70 and elapsed_ms < 500;
+    if (ok) {
+        reportResult("request_many_max_wait", true, "");
+    } else {
+        var buf: [80]u8 = undefined;
+        const detail = std.fmt.bufPrint(
+            &buf,
+            "got={d} term={s} ms={d}",
+            .{
+                got,
+                @tagName(iter.termination),
+                elapsed_ms,
+            },
+        ) catch "e";
+        reportResult("request_many_max_wait", false, detail);
+    }
+}
+
+const DelayedResponder = struct {
+    fn handle(
+        c: *nats.Client,
+        s: *nats.Subscription,
+        io: std.Io,
+        delay_ms: u32,
+    ) void {
+        const req = s.nextMsgTimeout(3000) catch return;
+        const m = req orelse return;
+        defer m.deinit();
+        const reply = m.reply_to orelse return;
+        io.sleep(.fromMilliseconds(delay_ms), .awake) catch return;
+        c.publish(reply, "ok") catch return;
+    }
+};
+
+// Verifies ADR-47 stall semantics: the first reply still gets the
+// full max_wait_ms (stall_ms must not fire before any reply). The
+// stall timer only applies between replies. Without the fix, this
+// test would terminate at ~stall_ms with 0 messages.
+pub fn testRequestManyStall(allocator: std.mem.Allocator) void {
+    var url_buf: [64]u8 = undefined;
+    const url = formatUrl(&url_buf, test_port);
+
+    const io_r = utils.newIo(allocator);
+    defer io_r.deinit();
+    const responder = nats.Client.connect(
+        allocator,
+        io_r.io(),
+        url,
+        .{ .reconnect = false },
+    ) catch {
+        reportResult(
+            "request_many_stall",
+            false,
+            "responder connect failed",
+        );
+        return;
+    };
+    defer responder.deinit();
+
+    const sub = responder.subscribeSync(
+        "rm.stall.service",
+    ) catch {
+        reportResult(
+            "request_many_stall",
+            false,
+            "responder sub failed",
+        );
+        return;
+    };
+    defer sub.deinit();
+    io_r.io().sleep(.fromMilliseconds(50), .awake) catch {};
+
+    var fut = io_r.io().async(
+        DelayedResponder.handle,
+        .{ responder, sub, io_r.io(), @as(u32, 300) },
+    );
+    defer _ = fut.cancel(io_r.io());
+
+    const io_req = utils.newIo(allocator);
+    defer io_req.deinit();
+    const requester = nats.Client.connect(
+        allocator,
+        io_req.io(),
+        url,
+        .{ .reconnect = false },
+    ) catch {
+        reportResult(
+            "request_many_stall",
+            false,
+            "requester connect failed",
+        );
+        return;
+    };
+    defer requester.deinit();
+
+    const start = std.Io.Timestamp.now(io_req.io(), .awake);
+
+    var iter = requester.requestMany(
+        "rm.stall.service",
+        "ping",
+        .{
+            .max_wait_ms = 2000,
+            .stall_ms = 100,
+        },
+    ) catch {
+        reportResult(
+            "request_many_stall",
+            false,
+            "requestMany failed",
+        );
+        return;
+    };
+    defer iter.deinit();
+
+    var got: u32 = 0;
+    while (iter.next() catch null) |msg| {
+        defer msg.deinit();
+        got += 1;
+    }
+
+    const end = std.Io.Timestamp.now(io_req.io(), .awake);
+    const elapsed_ns: i96 = end.nanoseconds - start.nanoseconds;
+    const elapsed_ms: i64 = @intCast(
+        @divFloor(elapsed_ns, std.time.ns_per_ms),
+    );
+
+    // First reply arrives ~300 ms in. Stall (100 ms) then fires
+    // ~400 ms. Without the fix, the call would end ~100 ms with
+    // got=0 and termination=.stall.
+    const ok = got == 1 and
+        iter.termination == .stall and
+        elapsed_ms >= 300 and elapsed_ms < 1500;
+    if (ok) {
+        reportResult("request_many_stall", true, "");
+    } else {
+        var buf: [96]u8 = undefined;
+        const detail = std.fmt.bufPrint(
+            &buf,
+            "got={d} term={s} ms={d}",
+            .{
+                got,
+                @tagName(iter.termination),
+                elapsed_ms,
+            },
+        ) catch "e";
+        reportResult("request_many_stall", false, detail);
+    }
+}
+
+// Verifies ADR-47 503/no-responders behavior: when the server has
+// no_responders enabled, an unbound subject ends the iterator with
+// termination=.no_responders rather than waiting out max_wait_ms.
+pub fn testRequestManyNoResponders(allocator: std.mem.Allocator) void {
+    var url_buf: [64]u8 = undefined;
+    const url = formatUrl(&url_buf, test_port);
+
+    const io = utils.newIo(allocator);
+    defer io.deinit();
+    const client = nats.Client.connect(
+        allocator,
+        io.io(),
+        url,
+        .{ .reconnect = false },
+    ) catch {
+        reportResult(
+            "request_many_no_responders",
+            false,
+            "connect failed",
+        );
+        return;
+    };
+    defer client.deinit();
+
+    const start = std.Io.Timestamp.now(io.io(), .awake);
+
+    var iter = client.requestMany(
+        "rm.absent.no_responders.subject",
+        "ping",
+        .{ .max_wait_ms = 2000 },
+    ) catch {
+        reportResult(
+            "request_many_no_responders",
+            false,
+            "requestMany failed",
+        );
+        return;
+    };
+    defer iter.deinit();
+
+    var got: u32 = 0;
+    while (iter.next() catch null) |msg| {
+        defer msg.deinit();
+        got += 1;
+    }
+
+    const end = std.Io.Timestamp.now(io.io(), .awake);
+    const elapsed_ns: i96 = end.nanoseconds - start.nanoseconds;
+    const elapsed_ms: i64 = @intCast(
+        @divFloor(elapsed_ns, std.time.ns_per_ms),
+    );
+
+    const ok = got == 0 and
+        iter.termination == .no_responders and
+        elapsed_ms < 1000;
+    if (ok) {
+        reportResult("request_many_no_responders", true, "");
+    } else {
+        var buf: [96]u8 = undefined;
+        const detail = std.fmt.bufPrint(
+            &buf,
+            "got={d} term={s} ms={d}",
+            .{
+                got,
+                @tagName(iter.termination),
+                elapsed_ms,
+            },
+        ) catch "e";
+        reportResult("request_many_no_responders", false, detail);
+    }
+}
+
+const CollectingHandler = struct {
+    count: *u32,
+    bytes: *u32,
+
+    pub fn onMessage(
+        self: *@This(),
+        msg: *const nats.Message,
+    ) void {
+        self.count.* += 1;
+        self.bytes.* += @intCast(msg.data.len);
+    }
+};
+
+// Verifies the callback variant of requestMany delivers each reply
+// to MsgHandler.onMessage and returns a RequestManyResult with the
+// correct count and termination reason.
+pub fn testRequestManyCallback(allocator: std.mem.Allocator) void {
+    var url_buf: [64]u8 = undefined;
+    const url = formatUrl(&url_buf, test_port);
+
+    const responder_count: u32 = 3;
+
+    var io_ctxs: [3]*utils.TestIo = undefined;
+    var responders: [3]*nats.Client = undefined;
+    var subs: [3]*nats.Subscription = undefined;
+    var futs: [3]std.Io.Future(void) = undefined;
+
+    var i: usize = 0;
+    while (i < responder_count) : (i += 1) {
+        io_ctxs[i] = utils.newIo(allocator);
+        responders[i] = nats.Client.connect(
+            allocator,
+            io_ctxs[i].io(),
+            url,
+            .{ .reconnect = false },
+        ) catch {
+            reportResult(
+                "request_many_callback",
+                false,
+                "responder connect failed",
+            );
+            return;
+        };
+        subs[i] = responders[i].subscribeSync(
+            "rm.cb.service",
+        ) catch {
+            reportResult(
+                "request_many_callback",
+                false,
+                "responder sub failed",
+            );
+            return;
+        };
+    }
+    defer {
+        var j: usize = responder_count;
+        while (j > 0) : (j -= 1) {
+            _ = futs[j - 1].cancel(io_ctxs[j - 1].io());
+            subs[j - 1].deinit();
+            responders[j - 1].deinit();
+            io_ctxs[j - 1].deinit();
+        }
+    }
+    io_ctxs[0].io().sleep(.fromMilliseconds(50), .awake) catch {};
+
+    i = 0;
+    while (i < responder_count) : (i += 1) {
+        futs[i] = io_ctxs[i].io().async(
+            ScatterResponder.handle,
+            .{ responders[i], subs[i], "abc" },
+        );
+    }
+
+    const io_req = utils.newIo(allocator);
+    defer io_req.deinit();
+    const requester = nats.Client.connect(
+        allocator,
+        io_req.io(),
+        url,
+        .{ .reconnect = false },
+    ) catch {
+        reportResult(
+            "request_many_callback",
+            false,
+            "requester connect failed",
+        );
+        return;
+    };
+    defer requester.deinit();
+
+    var count: u32 = 0;
+    var bytes: u32 = 0;
+    var handler = CollectingHandler{
+        .count = &count,
+        .bytes = &bytes,
+    };
+
+    const result = requester.requestManyCallback(
+        "rm.cb.service",
+        "ping",
+        .{
+            .max_wait_ms = 2000,
+            .max_messages = responder_count,
+        },
+        nats.MsgHandler.init(CollectingHandler, &handler),
+    ) catch {
+        reportResult(
+            "request_many_callback",
+            false,
+            "requestManyCallback failed",
+        );
+        return;
+    };
+
+    const ok = count == responder_count and
+        bytes == responder_count * 3 and
+        result.received == responder_count and
+        result.termination == .max_messages;
+    if (ok) {
+        reportResult("request_many_callback", true, "");
+    } else {
+        var buf: [96]u8 = undefined;
+        const detail = std.fmt.bufPrint(
+            &buf,
+            "count={d} bytes={d} recv={d} term={s}",
+            .{
+                count,
+                bytes,
+                result.received,
+                @tagName(result.termination),
+            },
+        ) catch "e";
+        reportResult("request_many_callback", false, detail);
+    }
+}
+
 pub fn runAll(allocator: std.mem.Allocator) void {
     testRequestMethod(allocator);
     testRequestReturns(allocator);
@@ -801,4 +1437,10 @@ pub fn runAll(allocator: std.mem.Allocator) void {
     testMuxerLatencyFloor(allocator);
     testMuxerRapidSequential(allocator);
     testMuxerTimeoutCleanup(allocator);
+    testRequestManyCount(allocator);
+    testRequestManySentinel(allocator);
+    testRequestManyMaxWait(allocator);
+    testRequestManyStall(allocator);
+    testRequestManyNoResponders(allocator);
+    testRequestManyCallback(allocator);
 }


### PR DESCRIPTION
## Summary

Implements one-to-many request/reply per [ADR-47](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-47.md)
with both iterator and callback APIs.

```zig
var iter = try client.requestMany("rpc.scatter", "ping", .{
    .max_wait_ms = 2000,
    .max_messages = 3,
});
defer iter.deinit();
while (try iter.next()) |msg| {
    defer msg.deinit();
    // ...
}
// iter.termination: .max_messages | .max_wait | .stall | .sentinel | .no_responders | .closed
```

### Stop conditions (race; first to fire ends the call)

| Field | Type | Purpose |
|---|---|---|
| `max_wait_ms` | `u32` (required, > 0) | Overall deadline. |
| `stall_ms` | `u32` (0 disables) | Gap between replies; only after the first reply. |
| `max_messages` | `u32` (0 disables) | Terminate after N replies. |
| `sentinel` | `?Sentinel` | Predicate; `emptyPayloadSentinel()` is the ADR-47 standard marker. |

A server-side 503 surfaces as `termination = .no_responders`.

### Isolation from `request()`

The iterator owns a dedicated two-token inbox subscription
(`<prefix>.<22 random>`) that cannot match the shared single-reply
response multiplexer wildcard (three tokens), so concurrent
`request()` and `requestMany()` traffic do not interfere.

### Spec conformance notes

Two ADR-47 details that are easy to miss are handled explicitly:

- **Stall before the first reply.** `stall_ms` only takes effect
  after at least one reply has arrived; the first message gets the
  full `max_wait_ms` window. Implemented by gating the per-wait
  cap on `received > 0`.
- **Callback dispatch time vs. deadline.** ADR-47: *"the client
  must account for the time it takes for the user to process the
  message and not consider that time against the timeouts."*
  `requestManyCallback` advances `iter.start_ns` by each
  dispatch's duration so a slow handler does not eat into
  `max_wait_ms`.

## What's in the PR

- `src/Client.zig` — `RequestManyOptions`, `RequestManyIter`,
  `RequestManyResult`, `RequestManyTermination`, `Sentinel`,
  `emptyPayloadSentinel()`, `requestMany()`, `requestManyCallback()`.
- `src/nats.zig` — module re-exports.
- `src/testing/client/request_reply.zig` — six tests:
  `testRequestManyCount`, `testRequestManySentinel`,
  `testRequestManyMaxWait`, `testRequestManyStall`,
  `testRequestManyNoResponders`, `testRequestManyCallback`.
- `src/examples/request_many.zig` + `build.zig` —
  `zig build run-request-many` runs a 3-worker scatter demo
  showing both forms.
- `README.md` — new *Scatter/Gather with `requestMany()`*
  subsection, examples table row, status entry.
- `CHANGELOG.md` (new) — Keep a Changelog format; covers this
  addition plus the prior pre-release review fixes under
  `[Unreleased]`, with a brief `[0.1.0]` summary.

## Test plan

- [x] `zig build` succeeds (Debug, native).
- [x] `zig build test-integration` — all 428 integration tests pass.
- [x] `zig build run-request-many` against a local `nats-server`:
  - iterator form yields three replies, terminates with `.max_messages`;
  - callback form yields three replies, returns
    `{ received = 3, termination = .max_messages }`.
- [x] Spec details (stall-only-after-first-reply, callback
  dispatch accounting) covered by `testRequestManyStall` and
  the callback path in `testRequestManyCallback`.

## Compatibility

- No public API removed or renamed; this is purely additive.
- New symbols re-exported from `nats`: `RequestManyOptions`,
  `RequestManyIter`, `RequestManyResult`, `RequestManyTermination`,
  `Sentinel`, `emptyPayloadSentinel`.
- Existing `request()` / `requestWithHeaders()` paths and the
  response multiplexer are untouched.
