### PR TITLE
Fix BADF panic in Client.deinit during disconnect (macOS)

### DIFF
--- a/src/Client.zig
+++ b/src/Client.zig
@@ -111,8 +111,10 @@ fn shutdownRecvIfOpen(self: *Client) void {
 
 /// Close the stream iff it is currently open. Clears the flag so a
 /// subsequent close is a no-op (deinit is documented as idempotent).
-/// Caller must ensure io_task has exited before calling, so there
-/// is no concurrent reassignment of self.stream.
+/// Caller must hold exclusive ownership of `self.stream` reassignment
+/// -- either io_task has exited (deinit / drain), or the caller IS
+/// io_task (cleanupForReconnect, tryConnect's errdefer). stream_mutex
+/// protects the close itself, not stream reassignment.
 fn closeIfOpen(self: *Client) void {
     self.stream_mutex.lockUncancelable(self.io);
     defer self.stream_mutex.unlock(self.io);
@@ -4065,6 +4067,12 @@ pub fn cleanupForReconnect(self: *Client) void {
     else |_|
         false;
 
+    // If write_mutex acquisition was cancelled we still proceed:
+    // state == .disconnected blocks any new writes, and an in-flight
+    // write hitting the closing fd will fail at the syscall. The
+    // stream close itself is serialized under stream_mutex by
+    // closeIfOpen, so the unprotected reader/writer resets below are
+    // only racing with writers that canSend() has already rejected.
     self.closeIfOpen();
     self.tls_client = null;
     // Reset to raw TCP to avoid dangling TLS pointers
@@ -4098,6 +4106,9 @@ pub fn tryConnect(
         self.stream = new_stream;
         self.stream_open = true;
     }
+    // errdefer MUST follow the lock block directly: no error-returning
+    // operations may be inserted between them, or new_stream would
+    // leak after stream_open=true but before the errdefer registers.
     errdefer self.closeIfOpen();
 
     // Set TCP_NODELAY

--- a/src/Client.zig
+++ b/src/Client.zig
@@ -96,17 +96,30 @@ pub const MsgHandler = struct {
     }
 };
 
-/// Checks if a file descriptor is valid using fcntl.
-/// Returns false for negative fds or closed fds.
-/// Used to guard shutdown/close calls that panic on
-/// BADF in debug mode (Io.Threaded treats as bug).
-fn isValidFd(fd: std.posix.fd_t) bool {
-    if (fd < 0) return false;
-    const F_GETFD = 1;
-    const rc = std.posix.system.fcntl(fd, F_GETFD, @as(c_int, 0));
-    // fcntl returns the fd flags on success, or a
-    // large unsigned value (wrapped errno) on failure
-    return rc < 0x1000;
+/// Shutdown the stream's read side iff it is currently open.
+/// Serializes against io_task's reconnect lifecycle via stream_mutex,
+/// so we never call shutdown on an fd that io_task has closed.
+/// Io.Threaded.netShutdownPosix panics in debug on BADF/NOTSOCK/INVAL,
+/// so the flag check must be inside the lock.
+fn shutdownRecvIfOpen(self: *Client) void {
+    self.stream_mutex.lockUncancelable(self.io);
+    defer self.stream_mutex.unlock(self.io);
+    if (self.stream_open) {
+        self.stream.shutdown(self.io, .recv) catch {};
+    }
+}
+
+/// Close the stream iff it is currently open. Clears the flag so a
+/// subsequent close is a no-op (deinit is documented as idempotent).
+/// Caller must ensure io_task has exited before calling, so there
+/// is no concurrent reassignment of self.stream.
+fn closeIfOpen(self: *Client) void {
+    self.stream_mutex.lockUncancelable(self.io);
+    defer self.stream_mutex.unlock(self.io);
+    if (self.stream_open) {
+        self.stream.close(self.io);
+        self.stream_open = false;
+    }
 }
 
 /// Gets current monotonic time in nanoseconds.
@@ -773,6 +786,13 @@ last_error_msg_len: u8 = 0,
 
 // Background I/O task infrastructure
 write_mutex: Io.Mutex = .init,
+/// Serializes lifecycle ops on `stream` (open/close/shutdown/reassign).
+/// Innermost lock — never nested with any other client mutex.
+/// Order: sub_mutex -> read_mutex -> write_mutex -> stream_mutex.
+stream_mutex: Io.Mutex = .init,
+/// True iff `stream` currently holds a live, owned fd.
+/// Only mutated while holding `stream_mutex`.
+stream_open: bool = false,
 /// Future for background I/O task (for proper cancellation in deinit).
 io_task_future: ?Io.Future(void) = null,
 
@@ -879,6 +899,8 @@ pub fn connect(
 
     // Initialize background I/O task infrastructure
     client.write_mutex = .init;
+    client.stream_mutex = .init;
+    client.stream_open = false;
     client.io_task_future = null;
     client.publish_ring_buf = null;
 
@@ -939,7 +961,8 @@ pub fn connect(
     }
 
     client.stream = try connectToHost(io, parsed.host, parsed.port);
-    errdefer client.stream.close(io);
+    client.stream_open = true;
+    errdefer client.closeIfOpen();
 
     // TCP_NODELAY
     const enable: u32 = 1;
@@ -2350,10 +2373,9 @@ pub fn forceReconnect(self: *Client) !void {
     // Shutdown read only -- in-flight writes stay safe.
     // io_task sees EndOfStream, enters handleDisconnect
     // which calls cleanupForReconnect for full close
-    // with write_mutex. Guard: fd may be invalid.
-    if (isValidFd(self.stream.socket.handle)) {
-        self.stream.shutdown(self.io, .recv) catch {};
-    }
+    // with write_mutex. Guarded by stream_mutex so we
+    // never shutdown an fd io_task has already closed.
+    self.shutdownRecvIfOpen();
 }
 
 /// Gracefully drains with a timeout.
@@ -2808,18 +2830,16 @@ pub fn drain(self: *Client) !DrainResult {
     self.pushEvent(.{ .draining = {} });
 
     State.atomicStore(&self.state, .closed);
-    // Shutdown read to unblock io_task. Guard: fd may
-    // already be closed by io_task during disconnect.
-    if (isValidFd(self.stream.socket.handle)) {
-        self.stream.shutdown(self.io, .recv) catch {};
-    }
+    // Shutdown read to unblock io_task. stream_mutex serializes
+    // against io_task closing the fd during reconnect.
+    self.shutdownRecvIfOpen();
     // Wait for io_task to exit
     if (self.io_task_future) |*future| {
         _ = future.cancel(self.io);
         self.io_task_future = null;
     }
-    // Full close -- io_task exited
-    self.stream.close(self.io);
+    // Full close -- io_task exited, no concurrent reassignment.
+    self.closeIfOpen();
 
     if (self.server_info) |*info| {
         info.deinit(alloc);
@@ -3438,15 +3458,11 @@ pub fn deinit(self: *Client) void {
     const was_open = State.atomicLoad(&self.state) != .closed;
     State.atomicStore(&self.state, .closed);
 
-    // 2. Shutdown read side only -- unblocks fillMore()
-    //    Write fd stays valid for in-flight writes.
-    //    Guard: fd may already be closed by io_task during
-    //    disconnect or failed reconnect. BADF panics in
-    //    debug mode (Io.Threaded treats it as programmer
-    //    bug, not catchable). Validate fd before syscall.
-    if (was_open and isValidFd(self.stream.socket.handle)) {
-        self.stream.shutdown(self.io, .recv) catch {};
-    }
+    // 2. Shutdown read side only -- unblocks fillMore().
+    //    stream_mutex serializes against io_task closing the fd
+    //    in cleanupForReconnect; closeIfOpen below handles the
+    //    case where io_task already owns/closed the fd.
+    if (was_open) self.shutdownRecvIfOpen();
 
     // 3. Wait for io_task to exit (no concurrent writers after)
     if (self.io_task_future) |*future| {
@@ -3454,10 +3470,8 @@ pub fn deinit(self: *Client) void {
         self.io_task_future = null;
     }
 
-    // 4. Full close -- io_task exited, no concurrent writers
-    if (was_open and isValidFd(self.stream.socket.handle)) {
-        self.stream.close(self.io);
-    }
+    // 4. Full close -- io_task exited, no concurrent reassignment.
+    self.closeIfOpen();
 
     // 5. Cancel callback task and free event queue
     // SAFETY: Set event_queue = null BEFORE canceling to signal callback_task
@@ -4046,19 +4060,18 @@ pub fn cleanupForReconnect(self: *Client) void {
     // Wait for in-flight main-thread writes.
     // State is already .disconnected -- no new
     // writes will start (canSend() returns false).
-    self.write_mutex.lock(self.io) catch {
-        self.stream.close(self.io);
-        self.tls_client = null;
-        self.active_reader = &self.reader.interface;
-        self.active_writer = &self.writer.interface;
-        return;
-    };
-    self.stream.close(self.io);
+    const write_locked = if (self.write_mutex.lock(self.io))
+        true
+    else |_|
+        false;
+
+    self.closeIfOpen();
     self.tls_client = null;
     // Reset to raw TCP to avoid dangling TLS pointers
     self.active_reader = &self.reader.interface;
     self.active_writer = &self.writer.interface;
-    self.write_mutex.unlock(self.io);
+
+    if (write_locked) self.write_mutex.unlock(self.io);
 }
 
 /// Attempt connection to a single server.
@@ -4076,9 +4089,16 @@ pub fn tryConnect(
         server.getUrl(),
     );
 
-    // Connect
-    self.stream = try connectToHost(self.io, raw_host, port);
-    errdefer self.stream.close(self.io);
+    // Connect, then atomically install the new stream so deinit/drain
+    // see a consistent (handle, stream_open) pair.
+    const new_stream = try connectToHost(self.io, raw_host, port);
+    {
+        self.stream_mutex.lockUncancelable(self.io);
+        defer self.stream_mutex.unlock(self.io);
+        self.stream = new_stream;
+        self.stream_open = true;
+    }
+    errdefer self.closeIfOpen();
 
     // Set TCP_NODELAY
     const enable: u32 = 1;


### PR DESCRIPTION
## Summary

Fixes a `programmer bug caused syscall error: BADF` panic from
`Client.deinit` → `self.stream.shutdown(self.io, .recv)` that surfaces
when integration tests run on macOS aarch64 (Zig 0.16). The same race
exists on Linux and in release builds, where it manifests silently as
`error.Unexpected` instead of a debug panic.

Two compounding bugs are addressed:

### Bug A — `isValidFd` is wrong on libc dispatch (macOS)

```zig
fn isValidFd(fd: std.posix.fd_t) bool {
    if (fd < 0) return false;
    const F_GETFD = 1;
    const rc = std.posix.system.fcntl(fd, F_GETFD, @as(c_int, 0));
    return rc < 0x1000;
}
```

On macOS, `std.posix.system` resolves to `std.c`, whose `fcntl`
returns a signed `c_int` and reports errors as `-1` with `errno`
set. The predicate `rc < 0x1000` evaluates to `-1 < 4096`, which is
**true** — closed fds are reported as valid.

The `rc < 0x1000` form was written for Linux's raw-syscall ABI,
where errors arrive as negative-errno wrapped into a large `usize`
(e.g. `-EBADF` becomes `0xFFFF...F7`, well above `0x1000`). That
convention does not apply through libc.

### Bug B — TOCTOU race with `io_task` reconnect lifecycle

`io_task` owns `self.stream` during disconnect / reconnect:

- `handleDisconnect` → `cleanupForReconnect` calls
  `self.stream.close(io)` on the old fd.
- `tryReconnectLoop` → `tryConnect` does
  `self.stream = try connectToHost(...)` — a non-atomic struct write.

The caller-side paths (`deinit`, `drain`, `forceReconnect`) read
`self.stream.socket.handle`, optionally check it with `isValidFd`,
then call `shutdown(.recv)` / `close()` — a classic check-then-act
window. Even after fixing the predicate, `io_task` can close and
reassign the fd in the gap, producing BADF / NOTSOCK / INVAL.

`Io.Threaded.netShutdownPosix` and `closeFd` treat those errnos as
programmer bugs via `errnoBug` (panic in debug, `error.Unexpected`
in release). The contract is: do not call shutdown/close on an fd
you don't own. The fix has to enforce that contract structurally.

## Fix

Replace the predicate with a lock + flag guarding the stream's
lifecycle:

- **`stream_mutex: Io.Mutex`** — innermost lock, never nested with
  any other client mutex.
- **`stream_open: bool`** — true iff `stream` currently holds a
  live, owned fd; only mutated under `stream_mutex`.
- **`shutdownRecvIfOpen()` / `closeIfOpen()`** — helpers that hold
  `stream_mutex` across the flag check *and* the syscall, so there
  is no window for `io_task` to close the fd between them.
- **`cleanupForReconnect`** clears the flag under the lock when it
  closes the old fd.
- **`tryConnect`** installs the new stream and sets the flag under
  the lock, so observers can never see a torn `(handle, flag)`
  pair. Its `errdefer` cleans up under the lock if a later step
  fails after install.
- **`connect()`** sets the flag right after the initial
  `connectToHost` succeeds; its `errdefer` uses `closeIfOpen` so
  the flag and the fd stay in sync on early-failure paths.
- **`isValidFd` is deleted** rather than patched — every previous
  call site is now covered by the lock+flag helpers, and a "fixed"
  predicate would only invite future call sites that re-introduce
  the TOCTOU.

Lock ordering remains:

```
sub_mutex -> read_mutex -> write_mutex -> stream_mutex
```

`stream_mutex` is only acquired during fd lifecycle ops, never
nested with another client mutex, and only held across short
syscalls (`shutdown(.recv)`, `close` via `Io`). Steady-state cost
in the publish/subscribe hot paths is zero — they never touch it.

Helpers use `lockUncancelable` because their callers are all
cleanup paths (`deinit`, `drain`, `forceReconnect`,
`cleanupForReconnect`, `tryConnect`'s errdefer) where a canceled
lock acquire would leave the stream in an inconsistent state.

## Why the existing test suite didn't catch this

Two things compound:

- On **Linux**, the broken `isValidFd` predicate happens to work
  by coincidence: raw-syscall returns wrap `-EBADF` to a large
  `usize` that satisfies `rc >= 0x1000`. The closed-fd-looks-valid
  path is never exercised, so the underlying TOCTOU never produces
  BADF in practice.
- On **macOS**, the predicate inverts and immediately produces
  the BADF; `errnoBug` panics in debug builds. The release-mode
  version silently swallows `error.Unexpected`.

`testAutoflushDuringDisconnect` already covers the disconnect /
reconnect race window — it's the test that surfaces the bug on
macOS — so once CI runs `zig build test-integration` on macOS,
the regression guard is in place automatically.

## What's in the PR

- `src/Client.zig`:
  - Replace `isValidFd` with `shutdownRecvIfOpen` and `closeIfOpen`.
  - Add `stream_mutex` and `stream_open` fields.
  - Update `connect`, `deinit`, `drain`, `forceReconnect`,
    `cleanupForReconnect`, `tryConnect` to maintain / honor the
    flag under the lock.

No public API changes, no behavior change for the steady-state
publish/subscribe paths.

## Follow-ups (not in this PR)

- Add `macos-latest` to the CI matrix so this class of bug is
  caught at PR time rather than via post-merge bug reports. Two
  platform-specific issues in the last week (PR #9 compile error,
  this BADF panic) argue for it on their own.
- Architectural cleanup: route all `stream` lifecycle through
  `io_task` so there is a single owner. The mutex+flag pattern
  is the right scoped fix, but the long-term shape is "only
  `io_task` ever closes the fd; `deinit`/`drain` flip state and
  wait." Worth a separate tracking issue.

## Test plan

- [x] `zig build` clean on Linux (Zig 0.16).
- [ ] `zig build test-integration` on Linux.
- [ ] `zig build test-integration` on macOS aarch64 — must pass
      `testAutoflushDuringDisconnect` without the BADF panic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
